### PR TITLE
Provided trimming for source and message of written eventlogentries

### DIFF
--- a/serilog-sinks-eventlog.sln
+++ b/serilog-sinks-eventlog.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.EventLog", "src\Serilog.Sinks.EventLog\Serilog.Sinks.EventLog.csproj", "{EEA8B8EB-0FE6-44C2-9D10-02B7E3DEAD06}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.EventLog.Tests", "src\Serilog.Sinks.EventLog.Tests\Serilog.Sinks.EventLog.Tests.csproj", "{A1CBA312-471B-47AE-AA6F-E7A6E27559D0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{EEA8B8EB-0FE6-44C2-9D10-02B7E3DEAD06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EEA8B8EB-0FE6-44C2-9D10-02B7E3DEAD06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEA8B8EB-0FE6-44C2-9D10-02B7E3DEAD06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1CBA312-471B-47AE-AA6F-E7A6E27559D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1CBA312-471B-47AE-AA6F-E7A6E27559D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1CBA312-471B-47AE-AA6F-E7A6E27559D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1CBA312-471B-47AE-AA6F-E7A6E27559D0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/serilog-sinks-eventlog.sln
+++ b/serilog-sinks-eventlog.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.EventLog", "src\Serilog.Sinks.EventLog\Serilog.Sinks.EventLog.csproj", "{EEA8B8EB-0FE6-44C2-9D10-02B7E3DEAD06}"
 EndProject

--- a/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
+++ b/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.EventLog.Tests
+{
+    [TestFixture]
+    public class EventLogSinkTests
+    {
+        [Test]
+        public void EmittingNormalEventsWorks()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.EventLog("EventLogSinkTests")
+                .CreateLogger();
+
+            var guid = Guid.NewGuid().ToString("D");
+            log.Information("This is a normal mesage with a {Guid}", guid);
+
+            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid),
+                "The message was not found in the eventlog.");
+        }
+
+        [Test]
+        public void UsingAngleBracketsInSourceWorks()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.EventLog("EventLogSink<Tests>")
+                .CreateLogger();
+
+            var guid = Guid.NewGuid().ToString("D");
+            log.Information("This is a normal mesage with a {Guid}", guid);
+
+            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid),
+                "The message was not found in the eventlog.");
+        }
+
+        [Test]
+        public void UsingSuperLongSourceNamesAreCorrectlyTrimmed()
+        {
+            for (var i = 199; i < 270; i+=10)
+            {
+                var log = new LoggerConfiguration()
+                    .WriteTo.EventLog("EventLogSinkTests" + new string('x', i - "EventLogSinkTests".Length))
+                    .CreateLogger();
+
+                var guid = Guid.NewGuid().ToString("D");
+                log.Information("This is a mesage with a {Guid}, source had length {length}", guid, i);
+
+                Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid), "The message was not found in the eventlog. SourceLength was " + i);
+            }
+        }
+
+        [Test]
+        public void UsingSuperLongLogMessageWorks()
+        {
+            var charcounts = new[]
+            {
+                10*1000,
+                20*1000,
+                30*1000,
+                40*1000,
+                70*1000
+            };
+            foreach (var charcount in charcounts)
+            {
+                var log = new LoggerConfiguration()
+                    .WriteTo.EventLog("EventLogSinkTests")
+                    .CreateLogger();
+
+                var guid = Guid.NewGuid().ToString("D");
+                log.Information("This is a super long message which might be trimmed. Guid is {Guid}.The following text has {charcount} chars: {LongText}"
+                    , guid
+                    , charcount
+                    , new string('x', charcount));
+
+                Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid), "The message was not found in the eventlog. Charcount was " + charcount);
+            }
+        }
+
+        [Test]
+        public void UsingSpecialCharsWorks()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.EventLog("EventLogSinkTests")
+                .CreateLogger();
+
+            var guid = Guid.NewGuid().ToString("D");
+            log.Information("This is a mesage with a {Guid} and a special char {char}", guid, "%1");
+
+            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid), "The message was not found in the eventlog.");
+        }
+
+        private bool EventLogMessageWithSpecificBodyExists(string partOfBody)
+        {
+            return ApplicationLog.Entries.Cast<EventLogEntry>().Any(entry => entry.Message.Contains(partOfBody));
+        }
+
+        private static System.Diagnostics.EventLog ApplicationLog
+        {
+            get { return System.Diagnostics.EventLog.GetEventLogs().First(log => log.Log == "Application"); }
+        }
+    }
+}

--- a/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
+++ b/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Moq;
 using NUnit.Framework;
-using Serilog.Events;
-using Serilog.Formatting;
 
 namespace Serilog.Sinks.EventLog.Tests
 {

--- a/src/Serilog.Sinks.EventLog.Tests/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.EventLog.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("Serilog.Sinks.EventLog.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyCopyright("Copyright © Serilog Contributors 2014")]

--- a/src/Serilog.Sinks.EventLog.Tests/Serilog.Sinks.EventLog.Tests.csproj
+++ b/src/Serilog.Sinks.EventLog.Tests/Serilog.Sinks.EventLog.Tests.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A1CBA312-471B-47AE-AA6F-E7A6E27559D0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Serilog.Sinks.EventLog.Tests</RootNamespace>
+    <AssemblyName>Serilog.Sinks.EventLog.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EventLogSinkTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog.Sinks.EventLog\Serilog.Sinks.EventLog.csproj">
+      <Project>{eea8b8eb-0fe6-44c2-9d10-02b7e3dead06}</Project>
+      <Name>Serilog.Sinks.EventLog</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Serilog.Sinks.EventLog.Tests/packages.config
+++ b/src/Serilog.Sinks.EventLog.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net452" userInstalled="true" />
+  <package id="Serilog" version="1.4.204" targetFramework="net452" userInstalled="true" />
+</packages>

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.nuspec
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Serilog.Sinks.EventLog</id>
     <version>$version$</version>
-    <authors>Jeremy Clarke</authors>
+    <authors>Jeremy Clarke, Fabian Wetzel</authors>
     <description>Serilog event sink that writes to the Windows event log.</description>
     <language>en-US</language>
     <projectUrl>http://serilog.net</projectUrl>


### PR DESCRIPTION
- the message is now trimmed to allow writing to the eventlog even for large messages
- provided unittests to show effectiveness of trimming

relates to https://github.com/serilog/serilog/issues/452