### PR TITLE
Allow nuget package installation with Serilog 2

### DIFF
--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.nuspec
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging eventlog event log viewer</tags>
     <dependencies>
-      <dependency id="Serilog" version="[1.5.7,2)" />
+      <dependency id="Serilog" version="1.5.7" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Updated nuspec dependency version so that the package can be installed with Serilog 2, and not restricted to less than 2.0.0.