### PR TITLE
Add Custom Event Log Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# http://EditorConfig.org
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.cs]
+charset = utf-8

--- a/serilog-sinks-eventlog.sln
+++ b/serilog-sinks-eventlog.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.EventLog", "src\Serilog.Sinks.EventLog\Serilog.Sinks.EventLog.csproj", "{EEA8B8EB-0FE6-44C2-9D10-02B7E3DEAD06}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.EventLog.Tests", "src\Serilog.Sinks.EventLog.Tests\Serilog.Sinks.EventLog.Tests.csproj", "{A1CBA312-471B-47AE-AA6F-E7A6E27559D0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1AE6C6F3-6380-4F04-8FE5-3BBACE95DA83}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
+++ b/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
@@ -8,6 +8,7 @@ namespace Serilog.Sinks.EventLog.Tests
     [TestFixture]
     public class EventLogSinkTests
     {
+        private const string CUSTOM_LOG_NAME = "serilog-eventlog-sink";
         private readonly string EVENT_LOG_SOURCE = "EventLogSinkTests";
 
         [Test]
@@ -97,40 +98,38 @@ namespace Serilog.Sinks.EventLog.Tests
         [Test]
         public void UsingCustomEventLogWorks()
         {
-            var customLogName = "serilog-eventlog-sink";
             var log = new LoggerConfiguration()
                 .WriteTo.EventLog(
                     //can't use same source in different log
-                    source: $"{EVENT_LOG_SOURCE}-{customLogName}", 
-                    logName: customLogName)
+                    source: $"{EVENT_LOG_SOURCE}-{CUSTOM_LOG_NAME}", 
+                    logName: CUSTOM_LOG_NAME)
                 .CreateLogger();
 
             var guid = Guid.NewGuid().ToString("D");
-            log.Information("This is a normal mesage with a {Guid} in log {customLogName}", guid, customLogName);
+            log.Information("This is a normal mesage with a {Guid} in log {CUSTOM_LOG_NAME}", guid, CUSTOM_LOG_NAME);
 
-            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid, customLogName),
+            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid, CUSTOM_LOG_NAME),
                 "The message was not found in the eventlog.");
         }
 
         [Test]
         public void UsingExistingSourceInCustomEventLogLogsRestartWarningAndLogsToApplicationLog()
         {
-            var customLogName = "serilog-eventlog-sink";
             var source = Guid.NewGuid().ToString("D");
             //create our source in the app log first
             System.Diagnostics.EventLog.CreateEventSource(new EventSourceCreationData(source, "Application"));
 
             //then try to use it in our custom log
             var log = new LoggerConfiguration()
-                .WriteTo.EventLog(source: source, logName: customLogName)
+                .WriteTo.EventLog(source: source, logName: CUSTOM_LOG_NAME)
                 .CreateLogger();
 
             var guid = Guid.NewGuid().ToString("D");
-            log.Information("This is a normal mesage with a {Guid} in log {customLogName}", guid, customLogName);
+            log.Information("This is a normal mesage with a {Guid} in log {customLogName}", guid, CUSTOM_LOG_NAME);
 
             Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid, "Application"),
                 "The message was not found in the eventlog.");
-            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(source, customLogName),
+            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(source, CUSTOM_LOG_NAME),
                 "The message was not found in the eventlog.");
 
             System.Diagnostics.EventLog.DeleteEventSource(source);

--- a/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
+++ b/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
@@ -112,6 +112,30 @@ namespace Serilog.Sinks.EventLog.Tests
                 "The message was not found in the eventlog.");
         }
 
+        [Test]
+        public void UsingExistingSourceInCustomEventLogLogsRestartWarningAndLogsToApplicationLog()
+        {
+            var customLogName = "serilog-eventlog-sink";
+            var source = Guid.NewGuid().ToString("D");
+            //create our source in the app log first
+            System.Diagnostics.EventLog.CreateEventSource(new EventSourceCreationData(source, "Application"));
+
+            //then try to use it in our custom log
+            var log = new LoggerConfiguration()
+                .WriteTo.EventLog(source: source, logName: customLogName)
+                .CreateLogger();
+
+            var guid = Guid.NewGuid().ToString("D");
+            log.Information("This is a normal mesage with a {Guid} in log {customLogName}", guid, customLogName);
+
+            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(guid, "Application"),
+                "The message was not found in the eventlog.");
+            Assert.IsTrue(EventLogMessageWithSpecificBodyExists(source, customLogName),
+                "The message was not found in the eventlog.");
+
+            System.Diagnostics.EventLog.DeleteEventSource(source);
+        }
+
         private bool EventLogMessageWithSpecificBodyExists(string partOfBody, string logName = "")
         {
             var log = string.IsNullOrWhiteSpace(logName) ? ApplicationLog : GetLog(logName);

--- a/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
+++ b/src/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
@@ -8,11 +8,13 @@ namespace Serilog.Sinks.EventLog.Tests
     [TestFixture]
     public class EventLogSinkTests
     {
+        private readonly string EVENT_LOG_SOURCE = "EventLogSinkTests";
+
         [Test]
         public void EmittingNormalEventsWorks()
         {
             var log = new LoggerConfiguration()
-                .WriteTo.EventLog("EventLogSinkTests")
+                .WriteTo.EventLog(EVENT_LOG_SOURCE)
                 .CreateLogger();
 
             var guid = Guid.NewGuid().ToString("D");
@@ -42,7 +44,7 @@ namespace Serilog.Sinks.EventLog.Tests
             for (var i = 199; i < 270; i+=10)
             {
                 var log = new LoggerConfiguration()
-                    .WriteTo.EventLog("EventLogSinkTests" + new string('x', i - "EventLogSinkTests".Length))
+                    .WriteTo.EventLog(EVENT_LOG_SOURCE + new string('x', i - EVENT_LOG_SOURCE.Length))
                     .CreateLogger();
 
                 var guid = Guid.NewGuid().ToString("D");
@@ -66,7 +68,7 @@ namespace Serilog.Sinks.EventLog.Tests
             foreach (var charcount in charcounts)
             {
                 var log = new LoggerConfiguration()
-                    .WriteTo.EventLog("EventLogSinkTests")
+                    .WriteTo.EventLog(EVENT_LOG_SOURCE)
                     .CreateLogger();
 
                 var guid = Guid.NewGuid().ToString("D");
@@ -83,7 +85,7 @@ namespace Serilog.Sinks.EventLog.Tests
         public void UsingSpecialCharsWorks()
         {
             var log = new LoggerConfiguration()
-                .WriteTo.EventLog("EventLogSinkTests")
+                .WriteTo.EventLog(EVENT_LOG_SOURCE)
                 .CreateLogger();
 
             var guid = Guid.NewGuid().ToString("D");
@@ -99,7 +101,7 @@ namespace Serilog.Sinks.EventLog.Tests
             var log = new LoggerConfiguration()
                 .WriteTo.EventLog(
                     //can't use same source in different log
-                    source: $"EventLogSinkTests-{customLogName}", 
+                    source: $"{EVENT_LOG_SOURCE}-{customLogName}", 
                     logName: customLogName)
                 .CreateLogger();
 

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -45,6 +45,7 @@
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Sinks\EventLog\EventIdHash.cs" />
     <Compile Include="Sinks\EventLog\EventLogSink.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventIdHash.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventIdHash.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Serilog.Formatting.Compact
+{
+    /// <summary>
+    /// Hash functions for message templates. See <see cref="Compute"/>.
+    /// </summary>
+    //This class is left internal bc it's been borrowed from here
+    //https://github.com/serilog/serilog-formatting-compact/blob/dev/src/Serilog.Formatting.Compact/Formatting/Compact/EventIdHash.cs
+    //Alternatively, we could take a dependency on the formatting library and use that event hash but the tradeoff would be
+    //adding an additional dependency to nuget- could result in binding redirects or version conflicts as asms are updated moving forward
+    internal static class EventIdHash
+    {
+        /// <summary>
+        /// Compute a 32-bit hash of the provided <paramref name="messageTemplate"/>. The
+        /// resulting hash value can be uses as an event id in lieu of transmitting the
+        /// full template string.
+        /// </summary>
+        /// <param name="messageTemplate">A message template.</param>
+        /// <returns>A 32-bit hash of the template.</returns>
+        public static uint Compute(string messageTemplate)
+        {
+            if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
+
+            // Jenkins one-at-a-time https://en.wikipedia.org/wiki/Jenkins_hash_function
+            unchecked
+            {
+                uint hash = 0;
+                for (var i = 0; i < messageTemplate.Length; ++i)
+                {
+                    hash += messageTemplate[i];
+                    hash += (hash << 10);
+                    hash ^= (hash >> 6);
+                }
+                hash += (hash << 3);
+                hash ^= (hash >> 11);
+                hash += (hash << 15);
+                return hash;
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2014 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -116,7 +116,7 @@ namespace Serilog.Sinks.EventLog
 
             _log.Source = source;
 	    }
-     
+
 	    /// <summary>
 	    /// Emit the provided log event to the sink.
 	    /// </summary>

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
@@ -77,53 +77,52 @@ namespace Serilog.Sinks.EventLog
             _log.Source = source;
 	    }
 
-	    /// <summary>
-		/// Emit the provided log event to the sink.
-		/// </summary>
-		/// <param name="logEvent">The log event to write.</param>
-		/// <remarks>
-		/// <see cref="LogEventLevel.Debug" />, <see cref="LogEventLevel.Information" /> and <see cref="LogEventLevel.Verbose" /> are registered as <see cref="EventLogEntryType.Information" />.
-		/// <see cref="LogEventLevel.Error" />, <see cref="LogEventLevel.Fatal" /> are registered as <see cref="EventLogEntryType.Error" />.
-		/// <see cref="LogEventLevel.Warning" /> are registered as <see cref="EventLogEntryType.Warning" />.
-		/// The Event ID in the Windows log will be set to the integer value of the <paramref name="logEvent"/>'s <see cref="LogEvent.Level"/> property, so that the log can be filtered with more granularity.</remarks>
-		public void Emit(LogEvent logEvent)
-		{
-			if (logEvent == null) throw new ArgumentNullException("logEvent");
+        /// <summary>
+	    /// Emit the provided log event to the sink.
+	    /// </summary>
+	    /// <param name="logEvent">The log event to write.</param>
+	    /// <remarks>
+	    /// <see cref="LogEventLevel.Debug" />, <see cref="LogEventLevel.Information" /> and <see cref="LogEventLevel.Verbose" /> are registered as <see cref="EventLogEntryType.Information" />.
+	    /// <see cref="LogEventLevel.Error" />, <see cref="LogEventLevel.Fatal" /> are registered as <see cref="EventLogEntryType.Error" />.
+	    /// <see cref="LogEventLevel.Warning" /> are registered as <see cref="EventLogEntryType.Warning" />.
+	    /// The Event ID in the Windows log will be set to the integer value of the <paramref name="logEvent"/>'s <see cref="LogEvent.Level"/> property, so that the log can be filtered with more granularity.</remarks>
+	    public void Emit(LogEvent logEvent)
+	    {
+	        if (logEvent == null) throw new ArgumentNullException("logEvent");
 
-			EventLogEntryType type;
-			switch (logEvent.Level)
-			{
-				case LogEventLevel.Debug:
-				case LogEventLevel.Information:
-				case LogEventLevel.Verbose:
-					type = EventLogEntryType.Information;
-					break;
+	        EventLogEntryType type;
+	        switch (logEvent.Level)
+	        {
+	            case LogEventLevel.Debug:
+	            case LogEventLevel.Information:
+	            case LogEventLevel.Verbose:
+	                type = EventLogEntryType.Information;
+	                break;
 
-				case LogEventLevel.Error:
-				case LogEventLevel.Fatal:
-					type = EventLogEntryType.Error;
-					break;
+	            case LogEventLevel.Error:
+	            case LogEventLevel.Fatal:
+	                type = EventLogEntryType.Error;
+	                break;
 
-				case LogEventLevel.Warning:
-					type = EventLogEntryType.Warning;
-					break;
+	            case LogEventLevel.Warning:
+	                type = EventLogEntryType.Warning;
+	                break;
 
-				default:
-					SelfLog.WriteLine("Unexpected logging level, writing to EventLog as Information");
-					type = EventLogEntryType.Information;
-					break;
-			}
+	            default:
+	                SelfLog.WriteLine("Unexpected logging level, writing to EventLog as Information");
+	                type = EventLogEntryType.Information;
+	                break;
+	        }
 
-			var payloadWriter = new StringWriter();
-			_textFormatter.Format(logEvent, payloadWriter);
+	        var payloadWriter = new StringWriter();
+	        _textFormatter.Format(logEvent, payloadWriter);
 
-
-            //The payload is limitted in length and allowed chars
-            //see: https://msdn.microsoft.com/en-us/library/e29k5ebc%28v=vs.110%29.aspx
-            var payload = payloadWriter.ToString();
+	        //The payload is limitted in length and allowed chars
+	        //see: https://msdn.microsoft.com/en-us/library/e29k5ebc%28v=vs.110%29.aspx
+	        var payload = payloadWriter.ToString();
 	        if (payload.Length > 31839)
 	        {
-                //trim
+	            //trim
 	            payload = payload.Substring(0, 31839);
 	        }
 

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
@@ -48,9 +48,8 @@ namespace Serilog.Sinks.EventLog
 	    public EventLogSink(string source, string logName, ITextFormatter textFormatter, string machineName,
 	        bool manageEventSource)
 	    {
-	        if (source == null) throw new ArgumentNullException("source");
-	        if (textFormatter == null) throw new ArgumentNullException("textFormatter");
-
+	        if (source == null) throw new ArgumentNullException(nameof(source));
+	        if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
 
 	        //The source is limitted in length and allowed chars
 	        //see: https://msdn.microsoft.com/en-us/library/e29k5ebc%28v=vs.110%29.aspx

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
@@ -22,6 +22,7 @@ using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
+using Serilog.Formatting.Compact;
 
 namespace Serilog.Sinks.EventLog
 {
@@ -99,9 +100,9 @@ namespace Serilog.Sinks.EventLog
 
                             _log.Source = metaSource;
                             _log.WriteEntry(
-                                message: $"Event source {source} was previously registered in log {existingLogWithSource.Log}. " +
+                                message: $"Event source {source} was previously registered in log {existingLogWithSourceName}. " +
                                     $"The source has been registered with this log, {logName}, however a computer restart is required " +
-                                    $"before event logs will appear in {logName} with source {source}. Until then, messages will be logged to {existingLogWithSource.Log}.",
+                                    $"before event logs will appear in {logName} with source {source}. Until then, messages will be logged to {existingLogWithSourceName}.",
                                 type: EventLogEntryType.Warning,
                                 eventID: (int)LogEventLevel.Warning);
                         };
@@ -169,7 +170,9 @@ namespace Serilog.Sinks.EventLog
 	        _log.WriteEntry(
 	            message: payload,
 	            type: type,
-	            eventID: (int) logEvent.Level);
+                //even though the api is type int, eventID must be between 0 and 65535
+                //https://msdn.microsoft.com/en-us/library/d3159s0c(v=vs.110).aspx
+                eventID: (ushort)(EventIdHash.Compute(logEvent.MessageTemplate.Text)));
 	    }
 	}
 }

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
@@ -30,6 +31,9 @@ namespace Serilog.Sinks.EventLog
 	{
 		readonly ITextFormatter _textFormatter;
 		readonly string _source;
+	    readonly string _logName;
+	    const string APPLICATION_LOG = "Application";
+        System.Diagnostics.EventLog _log;
 
 	    /// <summary>
 	    /// Construct a sink posting to the Windows event log, creating the specified <paramref name="source"/> if it does not exist.
@@ -53,6 +57,12 @@ namespace Serilog.Sinks.EventLog
 
 	        _textFormatter = textFormatter;
 	        _source = source;
+	        _logName = logName;
+
+	        if (string.IsNullOrWhiteSpace(_logName))
+	            _logName = APPLICATION_LOG;
+
+	        _log = new System.Diagnostics.EventLog(_logName);
 
 	        var sourceData = new EventSourceCreationData(source, logName) {MachineName = machineName};
 
@@ -63,6 +73,8 @@ namespace Serilog.Sinks.EventLog
 	                System.Diagnostics.EventLog.CreateEventSource(sourceData);
 	            }
 	        }
+
+            _log.Source = source;
 	    }
 
 	    /// <summary>
@@ -115,7 +127,10 @@ namespace Serilog.Sinks.EventLog
 	            payload = payload.Substring(0, 31839);
 	        }
 
-            System.Diagnostics.EventLog.WriteEntry(_source, payload, type, (int)logEvent.Level);
-		}
+	        _log.WriteEntry(
+	            message: payload,
+	            type: type,
+	            eventID: (int) logEvent.Level);
+	    }
 	}
 }


### PR DESCRIPTION
There's a `logName` parameter to specify a custom event log in this sink, but it wasn't implemented.

- Added support for custom Windows Event Logs
- Added support for using sources previously registered with other logs
    - Windows requires a restart for this to take affect so the sink prefers logging successfully (vs throwing)  to the old log and adds a log entry in the custom log `logName` the user was trying to log to noting why the log message they wrote doesn't appear (source was previously registered with another log)
- New tests for both of these features

There didn't appear to be any contribution guidelines for modifying existing sinks, so please let me know if I'm missing something!