### PR TITLE
feat: possibility to create JSON formatted events

### DIFF
--- a/src/Serilog.Sinks.EventLog.Tests/Serilog.Sinks.EventLog.Tests.csproj
+++ b/src/Serilog.Sinks.EventLog.Tests/Serilog.Sinks.EventLog.Tests.csproj
@@ -31,15 +31,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.2.1.0\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Settings.AppSettings.2.0.0\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -59,8 +68,15 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Serilog.Sinks.EventLog.Tests/app.config
+++ b/src/Serilog.Sinks.EventLog.Tests/app.config
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="serilog:using:EventLog" value="Serilog.Sinks.EventLog" />
+    <add key="serilog:write-to:EventLog.source" value="EventLogSinkTests" />
+    <add key="serilog:write-to:EventLog.formatter" value="Serilog.Formatting.Json.JsonFormatter, Serilog" />
+  </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/src/Serilog.Sinks.EventLog.Tests/packages.config
+++ b/src/Serilog.Sinks.EventLog.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="Serilog" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog" version="2.1.0" targetFramework="net45" />
+  <package id="Serilog.Settings.AppSettings" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
+++ b/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2014 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.EventLog;
+using Serilog.Formatting;
 
 namespace Serilog
 {
@@ -57,5 +58,37 @@ namespace Serilog
 
 			return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource), restrictedToMinimumLevel);
 		}
-	}
+
+        /// <summary>
+        /// Adds a sink that writes log events to the Windows event log.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="source">The source name by which the application is registered on the local computer.</param>
+        /// <param name="logName">The name of the log the source's entries are written to. Possible values include Application, System, or a custom event log.</param>
+        /// <param name="machineName">The name of the machine hosting the event log written to.  The local machine by default.</param>
+        /// <param name="manageEventSource">If false does not check/create event source.  Defaults to true i.e. allow sink to manage event source creation</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="formatter">Formatter to control how events are rendered into the file. To control
+        /// plain text formatting, use the overload that accepts an output template instead.</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+		public static LoggerConfiguration EventLog(
+            this LoggerSinkConfiguration loggerConfiguration,
+            ITextFormatter formatter,
+            string source,
+            string logName = null,
+            string machineName = ".",
+            bool manageEventSource = true,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum
+            )
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (formatter == null) throw new ArgumentNullException(nameof(formatter));
+
+            return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource), restrictedToMinimumLevel);
+        }
+    }
 }

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.2.1.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Serilog.Sinks.EventLog/packages.config
+++ b/src/Serilog.Sinks.EventLog/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi guys, 

I needed to add the possibility to create JSON formatted events as a buffer to our ELK Stack (Now the Elastic Stack)  

- Added support for formatting events using the serilog JsonFormatter (code first)
- Added support for formatting events using the serilog JsonFormatter (using appsettings)
- New tests for both of these features

I added Newtonsoft.Json nuget package to unit test the rendered JSON log event message
I upgraded Serilog from v2.0 to v2.1 because strangely there was a bug when reading the configuration from the appSettings

Hope you will find this interesting!
