### PR TITLE
Add .NET core support via Windows Compatibility Pack

### DIFF
--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.0;</TargetFrameworks>
     <AssemblyName>Sample</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Sample</PackageId>
@@ -14,10 +14,4 @@
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.3.0" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
 </Project>

--- a/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
+++ b/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
@@ -18,6 +18,7 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.EventLog;
 using Serilog.Formatting;
+using System.Runtime.InteropServices;
 
 namespace Serilog
 {
@@ -53,7 +54,16 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IEventIdProvider eventIdProvider = null)
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (loggerConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(loggerConfiguration));
+            }
+
+            // Verify the code is running on Windows.
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException(RuntimeInformation.OSDescription);
+            }
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
 

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -7,7 +7,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>3.1.0</VersionPrefix>
     <Authors>Jeremy Clarke;Fabian Wetzel</Authors>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.EventLog</AssemblyName>
@@ -26,11 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="4.5.0-preview1-25914-04" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
 </Project>

--- a/test/Serilog.Sinks.EventLog.Tests/Serilog.Sinks.EventLog.Tests.csproj
+++ b/test/Serilog.Sinks.EventLog.Tests/Serilog.Sinks.EventLog.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.0;</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.EventLog.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -21,18 +21,13 @@
   </ItemGroup>
 
   <ItemGroup>    
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-      <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+      <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
       <PackageReference Include="Serilog" Version="2.3.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="2.3.1" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="1.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-      <PackageReference Include="NUnit" Version="3.5.0" />      
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+      <PackageReference Include="NUnit" Version="3.9.0" />      
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This should resolve issue https://github.com/serilog/serilog-sinks-eventlog/issues/24.

- updated Serilog.Sinks.EventLog sink target framework version to `netstandard2.0`. Package should be compatible with .NET Core 2.0 and .NET Framework 4.6.1 according to [.NET standard docs](https://github.com/dotnet/standard/blob/master/docs/versions.md).
- Added code to validate current OS platform
- Sample and Test projects frameworks were updated to `net461;netcoreapp2.0;`
- NUnit packages were updated to latest stable versions