### PR TITLE
Updated System.Diagnostics.EventLog package reference to release version.

### DIFF
--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Diagnostics.EventLog">
-      <Version>4.5.0-preview1-25914-04</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Completes https://github.com/serilog/serilog-sinks-eventlog/issues/24.