### PR TITLE
Modernize the project followup

### DIFF
--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0-windows;net8.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <NoWarn>CA1416</NoWarn>
     <LangVersion>12</LangVersion>
   </PropertyGroup>
 

--- a/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
+++ b/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
@@ -124,7 +124,7 @@ public static class LoggerConfigurationEventLogExtensions
     {
 #if NET5_0_OR_GREATER
         return OperatingSystem.IsWindows();
-#elif NET46X
+#elif NET462
         return true;
 #else
         return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);

--- a/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
+++ b/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 using System;
-using System.Runtime.Versioning;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.EventLog;
 using Serilog.Formatting;
 
-[assembly: SupportedOSPlatform("windows")]
+#if NET5_0_OR_GREATER
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
 
 namespace Serilog;
 

--- a/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
+++ b/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
@@ -19,7 +19,8 @@ using Serilog.Formatting.Display;
 using Serilog.Sinks.EventLog;
 using Serilog.Formatting;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
+
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]
 
 namespace Serilog;
 
@@ -44,9 +45,6 @@ public static class LoggerConfigurationEventLogExtensions
     /// <param name="eventIdProvider">Supplies event ids for emitted log events.</param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-#if FEATURE_SUPPORTEDOSPLATFORM
-    [SupportedOSPlatform("windows")]
-#endif
     public static LoggerConfiguration EventLog(
         this LoggerSinkConfiguration loggerConfiguration,
         string source,
@@ -58,12 +56,10 @@ public static class LoggerConfigurationEventLogExtensions
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         IEventIdProvider? eventIdProvider = null)
     {
-#if FEATURE_RUNTIMEINFORMATION
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return loggerConfiguration.Sink<NullSink>(restrictedToMinimumLevel);
         }
-#endif
 
         if (loggerConfiguration == null)
         {
@@ -97,9 +93,6 @@ public static class LoggerConfigurationEventLogExtensions
     /// </returns>
     /// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
     /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-#if FEATURE_SUPPORTEDOSPLATFORM
-    [SupportedOSPlatform("windows")]
-#endif
     public static LoggerConfiguration EventLog(
         this LoggerSinkConfiguration loggerConfiguration,
         ITextFormatter formatter,
@@ -110,12 +103,11 @@ public static class LoggerConfigurationEventLogExtensions
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         IEventIdProvider? eventIdProvider = null)
     {
-#if FEATURE_RUNTIMEINFORMATION
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return loggerConfiguration.Sink<NullSink>(restrictedToMinimumLevel);
         }
-#endif
+
         if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
         if (formatter == null) throw new ArgumentNullException(nameof(formatter));
 

--- a/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
+++ b/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 using System;
+using System.Runtime.Versioning;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.EventLog;
 using Serilog.Formatting;
-using System.Runtime.InteropServices;
 
-[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]
+[assembly: SupportedOSPlatform("windows")]
 
 namespace Serilog;
 
@@ -56,7 +56,7 @@ public static class LoggerConfigurationEventLogExtensions
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         IEventIdProvider? eventIdProvider = null)
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!IsWindows())
         {
             return loggerConfiguration.Sink<NullSink>(restrictedToMinimumLevel);
         }
@@ -103,7 +103,7 @@ public static class LoggerConfigurationEventLogExtensions
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         IEventIdProvider? eventIdProvider = null)
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!IsWindows())
         {
             return loggerConfiguration.Sink<NullSink>(restrictedToMinimumLevel);
         }
@@ -117,5 +117,16 @@ public static class LoggerConfigurationEventLogExtensions
         }
 
         return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider), restrictedToMinimumLevel);
+    }
+
+    private static bool IsWindows()
+    {
+#if NET5_0_OR_GREATER
+        return OperatingSystem.IsWindows();
+#elif NET46X
+        return true;
+#else
+        return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+#endif
     }
 }

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>Serilog event sink that writes to the Windows Event Log.</Description>
@@ -32,28 +32,12 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-        <DefineConstants>$(DefineConstants);FEATURE_SUPPORTEDOSPLATFORM;FEATURE_RUNTIMEINFORMATION</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <DefineConstants>$(DefineConstants);FEATURE_SUPPORTEDOSPLATFORM;FEATURE_RUNTIMEINFORMATION</DefineConstants>
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Serilog" Version="4.0.0"/>
-        <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all"/>
+        <PackageReference Include="Polyfill" Version="5.5.3" PrivateAssets="all"/>
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-        <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <ItemGroup Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">
         <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
     </ItemGroup>
 

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -22,7 +22,7 @@
         <PackageIcon>serilog-sink-nuget.png</PackageIcon>
         <PackageProjectUrl>https://serilog.net</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/serilog/serilog-sinks-eventlog</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>Serilog event sink that writes to the Windows Event Log.</Description>
@@ -15,18 +15,14 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageTags>serilog;logging;eventlog;event;log;viewer</PackageTags>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>Serilog</RootNamespace>
         <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
         <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-        <PackageTags>serilog;async</PackageTags>
         <PackageIcon>serilog-sink-nuget.png</PackageIcon>
         <PackageProjectUrl>https://serilog.net</PackageProjectUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/serilog/serilog-sinks-async</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <RepositoryUrl>https://github.com/serilog/serilog-sinks-eventlog</RepositoryUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -30,7 +30,7 @@
 
     <ItemGroup>
         <PackageReference Include="Serilog" Version="4.0.0"/>
-        <PackageReference Include="Polyfill" Version="5.5.3" PrivateAssets="all"/>
+        <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all"/>
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.Versioning;
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
@@ -27,9 +26,6 @@ namespace Serilog.Sinks.EventLog;
 /// Writes log events as documents to the Windows event log.
 /// </summary>
 /// <remarks>Beware of changing the source/log name, see: http://stackoverflow.com/questions/804284/how-do-i-write-to-a-custom-windows-event-log?rq=1</remarks>
-#if FEATURE_SUPPORTEDOSPLATFORM
-[SupportedOSPlatform("windows")]
-#endif
 public class EventLogSink : ILogEventSink
 {
     const string ApplicationLogName = "Application";


### PR DESCRIPTION
Since #55 became unmergeable, I reapplied some of the fixes in this new pull request.

* In the sample app, target `net6.0-windows` and `net8.0-windows` instead of suppressing `CA1416`
* Declare [SupportedOSPlatform("windows")] at the assembly level, ~with the help of the [Polyfill][1] package to avoid conditional compilation~
* Always return the NullSink when not running on Windows no matter what platform the package is compiled for
* Simplify the conditional package reference to `System.Diagnostics.EventLog` with `$(TargetFrameworkIdentifier) != '.NETFramework'`
* Remove the `Nullable` package (the ~`Polyfill`~ `PolySharp` package has everything needed for nullable annotations on .NET Standard 2.0 and more)
* Cleanup some project properties
  * `GenerateDocumentationFile` and `TreatWarningsAsErrors` were duplicated
  * `PackageTags` was duplicated (and wrong)
  * Fix `RepositoryUrl` (serilog-sinks-eventlog instead of serilog-sinks-async)
  * Remove `RepositoryType` = `git` (which is the default)

[1]: https://github.com/SimonCropp/Polyfill