### PR TITLE
Add support for task category injection

### DIFF
--- a/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
+++ b/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+// Copyright 2014 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ public static class LoggerConfigurationEventLogExtensions
     /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
     /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
     /// <param name="eventIdProvider">Supplies event ids for emitted log events.</param>
+    /// <param name="categoryNumberProvider">Supplies categories for emitted log events.</param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
     public static LoggerConfiguration EventLog(
@@ -55,7 +56,8 @@ public static class LoggerConfigurationEventLogExtensions
         string outputTemplate = DefaultOutputTemplate,
         IFormatProvider? formatProvider = null,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-        IEventIdProvider? eventIdProvider = null)
+        IEventIdProvider? eventIdProvider = null,
+        ICategoryNumberProvider? categoryNumberProvider = null)
     {
         if (!IsWindows())
         {
@@ -69,12 +71,7 @@ public static class LoggerConfigurationEventLogExtensions
 
         var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
 
-        if (eventIdProvider == null)
-        {
-            return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource), restrictedToMinimumLevel);
-        }
-
-        return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider), restrictedToMinimumLevel);
+        return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider, categoryNumberProvider), restrictedToMinimumLevel);
     }
 
     /// <summary>
@@ -89,6 +86,7 @@ public static class LoggerConfigurationEventLogExtensions
     /// <param name="formatter">Formatter to control how events are rendered into the file. To control
     /// plain text formatting, use the overload that accepts an output template instead.</param>
     /// <param name="eventIdProvider">Supplies event ids for emitted log events.</param>
+    /// <param name="categoryNumberProvider">Supplies categories for emitted log events.</param>
     /// <returns>
     /// Logger configuration, allowing configuration to continue.
     /// </returns>
@@ -102,7 +100,8 @@ public static class LoggerConfigurationEventLogExtensions
         string machineName = ".",
         bool manageEventSource = false,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-        IEventIdProvider? eventIdProvider = null)
+        IEventIdProvider? eventIdProvider = null,
+        ICategoryNumberProvider? categoryNumberProvider = null)
     {
         if (!IsWindows())
         {
@@ -112,12 +111,7 @@ public static class LoggerConfigurationEventLogExtensions
         if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
         if (formatter == null) throw new ArgumentNullException(nameof(formatter));
 
-        if (eventIdProvider == null)
-        {
-            return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource), restrictedToMinimumLevel);
-        }
-
-        return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider), restrictedToMinimumLevel);
+        return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider, categoryNumberProvider), restrictedToMinimumLevel);
     }
 
     private static bool IsWindows()

--- a/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
+++ b/src/Serilog.Sinks.EventLog/LoggerConfigurationEventLogExtensions.cs
@@ -44,7 +44,7 @@ public static class LoggerConfigurationEventLogExtensions
     /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
     /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
     /// <param name="eventIdProvider">Supplies event ids for emitted log events.</param>
-    /// <param name="categoryNumberProvider">Supplies categories for emitted log events.</param>
+    /// <param name="categoryProvider">Supplies categories for emitted log events.</param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
     public static LoggerConfiguration EventLog(
@@ -57,7 +57,7 @@ public static class LoggerConfigurationEventLogExtensions
         IFormatProvider? formatProvider = null,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         IEventIdProvider? eventIdProvider = null,
-        ICategoryNumberProvider? categoryNumberProvider = null)
+        ICategoryProvider? categoryProvider = null)
     {
         if (!IsWindows())
         {
@@ -71,7 +71,7 @@ public static class LoggerConfigurationEventLogExtensions
 
         var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
 
-        return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider, categoryNumberProvider), restrictedToMinimumLevel);
+        return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider, categoryProvider), restrictedToMinimumLevel);
     }
 
     /// <summary>
@@ -86,7 +86,7 @@ public static class LoggerConfigurationEventLogExtensions
     /// <param name="formatter">Formatter to control how events are rendered into the file. To control
     /// plain text formatting, use the overload that accepts an output template instead.</param>
     /// <param name="eventIdProvider">Supplies event ids for emitted log events.</param>
-    /// <param name="categoryNumberProvider">Supplies categories for emitted log events.</param>
+    /// <param name="categoryProvider">Supplies categories for emitted log events.</param>
     /// <returns>
     /// Logger configuration, allowing configuration to continue.
     /// </returns>
@@ -101,7 +101,7 @@ public static class LoggerConfigurationEventLogExtensions
         bool manageEventSource = false,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         IEventIdProvider? eventIdProvider = null,
-        ICategoryNumberProvider? categoryNumberProvider = null)
+        ICategoryProvider? categoryProvider = null)
     {
         if (!IsWindows())
         {
@@ -111,7 +111,7 @@ public static class LoggerConfigurationEventLogExtensions
         if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
         if (formatter == null) throw new ArgumentNullException(nameof(formatter));
 
-        return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider, categoryNumberProvider), restrictedToMinimumLevel);
+        return loggerConfiguration.Sink(new EventLogSink(source, logName, formatter, machineName, manageEventSource, eventIdProvider, categoryProvider), restrictedToMinimumLevel);
     }
 
     private static bool IsWindows()

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -29,8 +29,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.0.0"/>
-        <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all"/>
+        <PackageReference Include="Serilog" Version="4.0.0" />
+        <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">
@@ -38,8 +38,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="/"/>
-        <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="/"/>
+        <None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="/" />
+        <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="/" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Properties\PublishProfiles\" />
     </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
+++ b/src/Serilog.Sinks.EventLog/Serilog.Sinks.EventLog.csproj
@@ -3,8 +3,8 @@
     <PropertyGroup>
         <Description>Serilog event sink that writes to the Windows Event Log.</Description>
         <Copyright>Copyright © Serilog Contributors</Copyright>
-        <VersionPrefix>4.0.1</VersionPrefix>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+        <VersionPrefix>5.0.0</VersionPrefix>
+        <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <Authors>Jeremy Clarke;Fabian Wetzel</Authors>
         <!-- .NET Framework version targeting is frozen at these two TFMs. -->
         <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>
@@ -40,10 +40,6 @@
     <ItemGroup>
         <None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="/" />
         <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="/" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Properties\PublishProfiles\" />
     </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
@@ -34,7 +34,7 @@ public class EventLogSink : ILogEventSink
     const int SourceMovedEventId = 3;
 
     readonly IEventIdProvider _eventIdProvider;
-    readonly ICategoryNumberProvider _categoryNumberProvider;
+    readonly ICategoryProvider _categoryProvider;
     readonly ITextFormatter _textFormatter;
     readonly System.Diagnostics.EventLog _log;
 
@@ -47,20 +47,11 @@ public class EventLogSink : ILogEventSink
     /// <param name="machineName">The name of the machine hosting the event log written to.</param>
     /// <param name="manageEventSource">If false does not check/create event source.  Defaults to true i.e. allow sink to manage event source creation</param>
     /// <param name="eventIdProvider">Supplies event ids for emitted log events.</param>
-    /// <param name="categoryNumberProvider">Supplies category numbers for emitted log events.</param>
-    public EventLogSink(string source, string? logName, ITextFormatter textFormatter, string machineName, bool manageEventSource, IEventIdProvider? eventIdProvider = null, ICategoryNumberProvider? categoryNumberProvider = null)
+    /// <param name="categoryProvider">Supplies categories for emitted log events.</param>
+    public EventLogSink(string source, string? logName, ITextFormatter textFormatter, string machineName, bool manageEventSource, IEventIdProvider? eventIdProvider = null, ICategoryProvider? categoryProvider = null)
     {
         if (source == null) throw new ArgumentNullException(nameof(source));
         if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
-        if (eventIdProvider == null)
-        {
-            eventIdProvider = new EventIdHashProvider();
-        }
-        if (categoryNumberProvider == null)
-        {
-            categoryNumberProvider = new NullCategoryNumberProvider();
-        }
-
 
         // The source is limited in length and allowed chars, see: https://msdn.microsoft.com/en-us/library/e29k5ebc%28v=vs.110%29.aspx
         if (source.Length > MaximumSourceNameLengthChars)
@@ -72,8 +63,8 @@ public class EventLogSink : ILogEventSink
         source = source.Replace("<", "_");
         source = source.Replace(">", "_");
 
-        _eventIdProvider = eventIdProvider;
-        _categoryNumberProvider = categoryNumberProvider;
+        _eventIdProvider = eventIdProvider ?? new EventIdHashProvider();
+        _categoryProvider = categoryProvider ?? new NullCategoryProvider();
         _textFormatter = textFormatter;
         _log = new System.Diagnostics.EventLog(string.IsNullOrWhiteSpace(logName) ? ApplicationLogName : logName, machineName);
 
@@ -156,7 +147,7 @@ public class EventLogSink : ILogEventSink
             payload = payload[..MaximumPayloadLengthChars];
         }
 
-        _log.WriteEntry(payload, type, _eventIdProvider.ComputeEventId(logEvent), category: _categoryNumberProvider.ComputeCategoryNumber(logEvent));
+        _log.WriteEntry(payload, type, _eventIdProvider.ComputeEventId(logEvent), category: _categoryProvider.ComputeCategory(logEvent));
     }
 
     static EventLogEntryType LevelToEventLogEntryType(LogEventLevel logEventLevel)

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/EventLogSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+// Copyright 2014 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ public class EventLogSink : ILogEventSink
     const int SourceMovedEventId = 3;
 
     readonly IEventIdProvider _eventIdProvider;
+    readonly ICategoryNumberProvider _categoryNumberProvider;
     readonly ITextFormatter _textFormatter;
     readonly System.Diagnostics.EventLog _log;
 
@@ -45,37 +46,34 @@ public class EventLogSink : ILogEventSink
     /// <param name="textFormatter">Supplies culture-specific formatting information, or null.</param>
     /// <param name="machineName">The name of the machine hosting the event log written to.</param>
     /// <param name="manageEventSource">If false does not check/create event source.  Defaults to true i.e. allow sink to manage event source creation</param>
-    public EventLogSink(string source, string? logName, ITextFormatter textFormatter, string machineName, bool manageEventSource)
-        : this(source, logName, textFormatter, machineName, manageEventSource, new EventIdHashProvider())
-    {
-    }
-
-    /// <summary>
-    /// Construct a sink posting to the Windows event log, creating the specified <paramref name="source"/> if it does not exist.
-    /// </summary>
-    /// <param name="source">The source name by which the application is registered on the local computer. </param>
-    /// <param name="logName">The name of the log the source's entries are written to. Possible values include Application, System, or a custom event log.</param>
-    /// <param name="textFormatter">Supplies culture-specific formatting information, or null.</param>
-    /// <param name="machineName">The name of the machine hosting the event log written to.</param>
-    /// <param name="manageEventSource">If false does not check/create event source.  Defaults to true i.e. allow sink to manage event source creation</param>
     /// <param name="eventIdProvider">Supplies event ids for emitted log events.</param>
-    public EventLogSink(string source, string? logName, ITextFormatter textFormatter, string machineName, bool manageEventSource, IEventIdProvider eventIdProvider)
+    /// <param name="categoryNumberProvider">Supplies category numbers for emitted log events.</param>
+    public EventLogSink(string source, string? logName, ITextFormatter textFormatter, string machineName, bool manageEventSource, IEventIdProvider? eventIdProvider = null, ICategoryNumberProvider? categoryNumberProvider = null)
     {
         if (source == null) throw new ArgumentNullException(nameof(source));
         if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
-        if (eventIdProvider == null) throw new ArgumentNullException(nameof(eventIdProvider));
+        if (eventIdProvider == null)
+        {
+            eventIdProvider = new EventIdHashProvider();
+        }
+        if (categoryNumberProvider == null)
+        {
+            categoryNumberProvider = new NullCategoryNumberProvider();
+        }
+
 
         // The source is limited in length and allowed chars, see: https://msdn.microsoft.com/en-us/library/e29k5ebc%28v=vs.110%29.aspx
         if (source.Length > MaximumSourceNameLengthChars)
         {
             SelfLog.WriteLine("Trimming long event log source name to {0} characters", MaximumSourceNameLengthChars);
-            source = source.Substring(0, MaximumSourceNameLengthChars);
+            source = source[..MaximumSourceNameLengthChars];
         }
 
         source = source.Replace("<", "_");
         source = source.Replace(">", "_");
 
         _eventIdProvider = eventIdProvider;
+        _categoryNumberProvider = categoryNumberProvider;
         _textFormatter = textFormatter;
         _log = new System.Diagnostics.EventLog(string.IsNullOrWhiteSpace(logName) ? ApplicationLogName : logName, machineName);
 
@@ -155,10 +153,10 @@ public class EventLogSink : ILogEventSink
         if (payload.Length > MaximumPayloadLengthChars)
         {
             SelfLog.WriteLine("Trimming long event log entry payload to {0} characters", MaximumPayloadLengthChars);
-            payload = payload.Substring(0, MaximumPayloadLengthChars);
+            payload = payload[..MaximumPayloadLengthChars];
         }
 
-        _log.WriteEntry(payload, type, _eventIdProvider.ComputeEventId(logEvent));
+        _log.WriteEntry(payload, type, _eventIdProvider.ComputeEventId(logEvent), category: _categoryNumberProvider.ComputeCategoryNumber(logEvent));
     }
 
     static EventLogEntryType LevelToEventLogEntryType(LogEventLevel logEventLevel)

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/ICategoryNumberProvider.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/ICategoryNumberProvider.cs
@@ -1,0 +1,31 @@
+// Copyright 2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Events;
+
+namespace Serilog.Sinks.EventLog
+{
+    /// <summary>
+    /// Task category number provider for log events
+    /// </summary>
+    public interface ICategoryNumberProvider
+    {
+        /// <summary>
+        /// Computes an task category number for the given log event.
+        /// </summary>
+        /// <param name="logEvent">The log event to compute the task category number from.</param>
+        /// <returns>Computed task category number based off the given log.</returns>
+        short ComputeCategoryNumber(LogEvent logEvent);
+    }
+}

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/ICategoryProvider.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/ICategoryProvider.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Serilog Contributors
+// Copyright 2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ using Serilog.Events;
 namespace Serilog.Sinks.EventLog
 {
     /// <summary>
-    /// Task category number provider for log events
+    /// Task category provider for log events
     /// </summary>
-    public interface ICategoryNumberProvider
+    public interface ICategoryProvider
     {
         /// <summary>
-        /// Computes an task category number for the given log event.
+        /// Computes an task category for the given log event.
         /// </summary>
-        /// <param name="logEvent">The log event to compute the task category number from.</param>
-        /// <returns>Computed task category number based off the given log.</returns>
-        short ComputeCategoryNumber(LogEvent logEvent);
+        /// <param name="logEvent">The log event to compute the task category from.</param>
+        /// <returns>Computed task category based off the given log.</returns>
+        short ComputeCategory(LogEvent logEvent);
     }
 }

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/NullCategoryProvider.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/NullCategoryProvider.cs
@@ -1,0 +1,26 @@
+// Copyright 2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Events;
+
+namespace Serilog.Sinks.EventLog;
+
+/// <summary>
+/// Always returns 0 as category number
+/// </summary>
+sealed class NullCategoryNumberProvider : ICategoryNumberProvider
+{
+
+    public short ComputeCategoryNumber(LogEvent logEvent) => 0;
+}

--- a/src/Serilog.Sinks.EventLog/Sinks/EventLog/NullCategoryProvider.cs
+++ b/src/Serilog.Sinks.EventLog/Sinks/EventLog/NullCategoryProvider.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Serilog Contributors
+// Copyright 2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@ namespace Serilog.Sinks.EventLog;
 /// <summary>
 /// Always returns 0 as category number
 /// </summary>
-sealed class NullCategoryNumberProvider : ICategoryNumberProvider
+sealed class NullCategoryProvider : ICategoryProvider
 {
-
-    public short ComputeCategoryNumber(LogEvent logEvent) => 0;
+    public short ComputeCategory(LogEvent logEvent) => 0;
 }

--- a/test/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
+++ b/test/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
@@ -30,7 +30,6 @@ namespace Serilog.Sinks.EventLog.Tests
             AssertJsonCarriesMessageTemplate(messageFromLogEvent, message);
         }
 
-
         [Fact]
         public void EmittingJsonFormattedEventsFromAppSettingsWorks()
         {

--- a/test/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
+++ b/test/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using Serilog.Formatting.Json;
@@ -204,12 +204,43 @@ namespace Serilog.Sinks.EventLog.Tests
                 "The message was with unknown event id not found in target event log.");
         }
 
+        [Fact]
+        public void UsingCustomCategoryProviderLogsMessagesWithSuppliedEventId()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.EventLog(EventLogSource, manageEventSource: true, categoryNumberProvider: new CustomCategoryNumberProvider())
+                .CreateLogger();
+
+            Assert.NotEqual(CustomCategoryNumberProvider.MessageWithKnownCategoryCategoryNumber, CustomCategoryNumberProvider.DefaultCategoryNumber);
+
+            var knownIdGuid = Guid.NewGuid().ToString("D");
+            log.Information(CustomCategoryNumberProvider.MessageWithKnownCategory, knownIdGuid);
+
+            Assert.True(EventLogMessageWithSpecificBodyAndCategoryExists(knownIdGuid, CustomCategoryNumberProvider.MessageWithKnownCategoryCategoryNumber),
+                "The message was with known event id not found in target event log.");
+
+            var unknownIdGuid = Guid.NewGuid().ToString("D");
+            log.Information("unknown message {Guid}", unknownIdGuid);
+
+            Assert.True(EventLogMessageWithSpecificBodyAndCategoryExists(unknownIdGuid, CustomCategoryNumberProvider.DefaultCategoryNumber),
+                "The message was with unknown event id not found in target event log.");
+        }
+
         static bool EventLogMessageWithSpecificBodyAndEventIdExists(string partOfBody, int eventId)
         {
             return ApplicationLog
                 .Entries
                 .Cast<EventLogEntry>()
                 .Any(entry => entry.InstanceId == eventId
+                              && entry.Message.Contains(partOfBody));
+        }
+
+        static bool EventLogMessageWithSpecificBodyAndCategoryExists(string partOfBody, short category)
+        {
+            return ApplicationLog
+                .Entries
+                .Cast<EventLogEntry>()
+                .Any(entry => entry.CategoryNumber == category
                               && entry.Message.Contains(partOfBody));
         }
 
@@ -244,6 +275,19 @@ namespace Serilog.Sinks.EventLog.Tests
             public ushort ComputeEventId(LogEvent logEvent)
             {
                 return string.Equals(logEvent.MessageTemplate.Text, MessageWithKnownId) ? MessageWithKnownIdEventId : UnknownEventId;
+            }
+        }
+
+        sealed class CustomCategoryNumberProvider : ICategoryNumberProvider
+        {
+            public const short DefaultCategoryNumber = 1;
+
+            public const short MessageWithKnownCategoryCategoryNumber = 12;
+            public const string MessageWithKnownCategory = "Event {Guid} - this message has a known id";
+
+            public short ComputeCategoryNumber(LogEvent logEvent)
+            {
+                return string.Equals(logEvent.MessageTemplate.Text, MessageWithKnownCategory) ? MessageWithKnownCategoryCategoryNumber : DefaultCategoryNumber;
             }
         }
     }

--- a/test/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
+++ b/test/Serilog.Sinks.EventLog.Tests/EventLogSinkTests.cs
@@ -205,25 +205,25 @@ namespace Serilog.Sinks.EventLog.Tests
         }
 
         [Fact]
-        public void UsingCustomCategoryProviderLogsMessagesWithSuppliedEventId()
+        public void UsingCustomCategoryProviderLogsMessagesWithSuppliedCategory()
         {
             var log = new LoggerConfiguration()
-                .WriteTo.EventLog(EventLogSource, manageEventSource: true, categoryNumberProvider: new CustomCategoryNumberProvider())
+                .WriteTo.EventLog(EventLogSource, manageEventSource: true, categoryProvider: new CustomCategoryNumberProvider())
                 .CreateLogger();
 
-            Assert.NotEqual(CustomCategoryNumberProvider.MessageWithKnownCategoryCategoryNumber, CustomCategoryNumberProvider.DefaultCategoryNumber);
+            Assert.NotEqual(CustomCategoryNumberProvider.MessageWithKnownCategoryNumber, CustomCategoryNumberProvider.DefaultCategoryNumber);
 
             var knownIdGuid = Guid.NewGuid().ToString("D");
             log.Information(CustomCategoryNumberProvider.MessageWithKnownCategory, knownIdGuid);
 
-            Assert.True(EventLogMessageWithSpecificBodyAndCategoryExists(knownIdGuid, CustomCategoryNumberProvider.MessageWithKnownCategoryCategoryNumber),
-                "The message was with known event id not found in target event log.");
+            Assert.True(EventLogMessageWithSpecificBodyAndCategoryExists(knownIdGuid, CustomCategoryNumberProvider.MessageWithKnownCategoryNumber),
+                "The message was with known category not found in target event log.");
 
             var unknownIdGuid = Guid.NewGuid().ToString("D");
             log.Information("unknown message {Guid}", unknownIdGuid);
 
             Assert.True(EventLogMessageWithSpecificBodyAndCategoryExists(unknownIdGuid, CustomCategoryNumberProvider.DefaultCategoryNumber),
-                "The message was with unknown event id not found in target event log.");
+                "The message was with default category not found in target event log.");
         }
 
         static bool EventLogMessageWithSpecificBodyAndEventIdExists(string partOfBody, int eventId)
@@ -278,16 +278,16 @@ namespace Serilog.Sinks.EventLog.Tests
             }
         }
 
-        sealed class CustomCategoryNumberProvider : ICategoryNumberProvider
+        sealed class CustomCategoryNumberProvider : ICategoryProvider
         {
             public const short DefaultCategoryNumber = 1;
 
-            public const short MessageWithKnownCategoryCategoryNumber = 12;
-            public const string MessageWithKnownCategory = "Event {Guid} - this message has a known id";
+            public const short MessageWithKnownCategoryNumber = 12;
+            public const string MessageWithKnownCategory = "Event {Guid} - this message has a known category";
 
-            public short ComputeCategoryNumber(LogEvent logEvent)
+            public short ComputeCategory(LogEvent logEvent)
             {
-                return string.Equals(logEvent.MessageTemplate.Text, MessageWithKnownCategory) ? MessageWithKnownCategoryCategoryNumber : DefaultCategoryNumber;
+                return string.Equals(logEvent.MessageTemplate.Text, MessageWithKnownCategory) ? MessageWithKnownCategoryNumber : DefaultCategoryNumber;
             }
         }
     }


### PR DESCRIPTION
This allows for the injection of task category numbers. You can see these numbers afterwards in the ¨Task Category¨ column within the event viewer.